### PR TITLE
copy html file in dist on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "prepublish": "yarn build",
-    "build": "mkdir -p dist && babel src/index.js --out-file dist/index.js",
+    "build": "mkdir -p dist && babel src --out-dir dist --copy-files",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "babel": {


### PR DESCRIPTION
This will fix #19 because
(file was not published on npm because not copied by babel )