### PR TITLE
createElement改为unstable_createElement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Qs from 'qs';
 import React, { Component } from 'react';
-import { StyleSheet, View, ActivityIndicator, createElement } from 'react-native';
+import { StyleSheet, View, ActivityIndicator, unstable_createElement as createElement } from 'react-native';
 
 export class WebView extends Component {
   static defaultProps = {


### PR DESCRIPTION
适配react-native-web@0.12.0版本，createElement改为unstable_createElement